### PR TITLE
🎨 Add mobile-service tag

### DIFF
--- a/fh-sync-server-DEVELOPMENT.yaml
+++ b/fh-sync-server-DEVELOPMENT.yaml
@@ -6,7 +6,7 @@ metadata:
     openshift.io/display-name: FeedHenry Sync (Persistent)
     description: FeedHenry Sync Server
     iconClass: icon-nodejs
-    tags: instant-app,sync
+    tags: instant-app,sync,mobile-service
     template.openshift.io/long-description: Data Synchronisation by FeedHenry.
     template.openshift.io/provider-display-name: FeedHenry
     template.openshift.io/documentation-url: https://github.com/feedhenry/fh-sync-server


### PR DESCRIPTION
Templates with the mobile-service tag get listed in the Mobile/Services
category in the Service Catalog

![image](https://user-images.githubusercontent.com/878251/29313028-9e596402-81af-11e7-8913-059b114b2f9a.png)
