### PR TITLE
FH-3785 Add initial dashboard for sync server

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ sync.connect(mongodbConnectionString, mongoOptions, redisUrl, function startAppl
     // middleware
   app.use(bodyParser.json());
   app.use(cors());
+  app.use(express.static('public'));
 
   app.get('/', function (req, res) {
     res.send('"OK"');
@@ -69,7 +70,9 @@ sync.connect(mongodbConnectionString, mongoOptions, redisUrl, function startAppl
           message: err.message || 'Could not retrieve sync stats.'
         });
       }
-      return res.json(stats);
+      return res.json({
+        metrics: stats
+      });
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -881,27 +881,29 @@
       "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.7.0.tgz",
       "integrity": "sha1-2FX+SJ2SE49wfnTUfmhfTDQ8QkI=",
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        "async": "2.1.5",
+        "lodash": "4.17.4"
       },
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
           "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
           "requires": {
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+            "lodash": "4.17.4"
           }
         },
         "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         }
       }
     },
     "fh-sync": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fh-sync/-/fh-sync-1.0.10.tgz",
-      "integrity": "sha1-5ZuBXQmrgmkC1HV8WOC5JkwqKa4=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fh-sync/-/fh-sync-1.0.11.tgz",
+      "integrity": "sha1-PqatsssYi8Vhh9vmODuDjDjW/bo=",
       "requires": {
         "async": "2.1.5",
         "backoff": "2.5.0",
@@ -930,9 +932,6 @@
           "requires": {
             "ms": "0.7.2"
           }
-        },
-        "mongodb-queue": {
-          "version": "git+https://github.com/david-martin/mongodb-queue.git#3867a46ea028b0c327d583492b8c566460a8e7f8"
         },
         "ms": {
           "version": "0.7.2",
@@ -1457,6 +1456,9 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mongodb-lock/-/mongodb-lock-0.4.0.tgz",
       "integrity": "sha1-mpMP0o5AcjT3HI/FOGEb7ya8hPM="
+    },
+    "mongodb-queue": {
+      "version": "git+https://github.com/david-martin/mongodb-queue.git#3867a46ea028b0c327d583492b8c566460a8e7f8"
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "body-parser": "^1.17.2",
     "cors": "^2.8.4",
     "express": "^4.15.3",
-    "fh-sync": "^1.0.10"
+    "fh-sync": "^1.0.11"
   },
   "devDependencies": {
     "semistandard": "^11.0.0"

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,27 @@
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly-additions.min.css">
+  </head>
+  <body>
+    <nav class="navbar navbar-default navbar-pf" role="navigation">
+      <div class="navbar-header">
+        <a class="navbar-brand" id="logo" href="/dashboard.html">
+          <img src="http://feedhenry.org/assets/images/logo.svg">
+            Sync Dashboard
+          </img>
+        </a>
+      </div>
+    </nav>
+    <div class="cards-pf">
+      <div class="container-fluid">
+        <div id="stats-container"></div>
+      </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.26.6/js/patternfly.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script src="/js/dashboard.js"></script>
+  </body>
+</html>

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,0 +1,133 @@
+/**
+ * Create a div element that and append it as a child for a selected
+ * node.
+ *
+ * @param {Object} statOptions
+ * @param {String} parentElementId The id of the element to add child
+ * node to.
+ */
+function createStatCard(statOptions, parentElement) {
+  // The outmost <div/>, this is a bootstrap column.
+  var columnElem = document.createElement('div');
+  columnElem.className = 'col-xs-6 col-sm-4 col-md-4';
+
+  // The actual patternfly card element.
+  var cardElem = document.createElement('div');
+  cardElem.className = 'card-pf card-pf-accented card-pf-aggregate-status';
+  cardElem.id = statOptions.idPrefix + statOptions.elementId || '';
+
+  // The card element itself.
+  var cardTitleElem = document.createElement('h2');
+  cardTitleElem.className = 'card-pf-title';
+  var cardTitle = document.createTextNode(statOptions.title);
+  cardTitleElem.appendChild(cardTitle);
+
+  // The body of the card.
+  var cardBodyElem = document.createElement('div');
+  cardBodyElem.className = 'card-pf-body';
+
+  // Outer contents of the card body.
+  var cardValueParagraphElem = document.createElement('p');
+  cardValueParagraphElem.className = 'card-pf-aggregate-status-notifications';
+
+  // The value of the card, add an id here so it can be updated in the future.
+  var cardValueSpanElem = document.createElement('span');
+  cardValueSpanElem.id = statOptions.idPrefix + statOptions.title + '-value';
+  cardValueSpanElem.className = 'card-pf-aggregate-status-notification';
+  var cardValue = document.createTextNode(statOptions.value);
+  cardValueSpanElem.appendChild(cardValue);
+
+  // Put everything together and append into the parent element.
+  cardValueParagraphElem.appendChild(cardValueSpanElem);
+  cardBodyElem.appendChild(cardValueParagraphElem);
+  cardElem.appendChild(cardTitleElem);
+  cardElem.appendChild(cardBodyElem);
+  columnElem.appendChild(cardElem);
+
+  parentElement.appendChild(columnElem);
+}
+
+/**
+ * Create a title section for each metric section. Metric cards should be
+ * appended inside the created <div>.
+ *
+ * @param {String} sectionName The title of the section
+ * @param {*} parentElement The element to append this section into
+ */
+function createStatSection(sectionName, parentElement) {
+  var sectionDiv = document.createElement('div');
+  sectionDiv.id = sectionName;
+  sectionDiv.className = 'row row-cards-pf';
+
+  var sectionTitle = document.createElement('h2');
+  sectionTitle.appendChild(document.createTextNode(sectionName));
+
+  sectionDiv.appendChild(sectionTitle);
+
+  parentElement.appendChild(sectionDiv);
+}
+
+/**
+ * Update the value of a metric.
+ *
+ * @param {Object} statOptions
+ * @param {String} statOptions.idPrefix Value to prefix when getting an element
+ * @param {String} statOptions.title The title of the element to update
+ * @param {String} statOptions.value The new value of the element
+ */
+function updateStatCard(statOptions) {
+  var cardValueElem = document.getElementById(statOptions.idPrefix + statOptions.title + '-value');
+  cardValueElem.innerText = statOptions.value;
+}
+
+/**
+ * Get stats from the stats endpoint in the server.
+ *
+ * @param {Function} cb Callback
+ */
+function retrieveSyncStats(cb) {
+  fetch('/sys/info/stats')
+  .then(res => res.json())
+  .then(cb)
+  .catch(err => console.error(err));
+}
+
+/**
+ * For each stat add or update element in page.
+ *
+ * @param {Object} statsResponse
+ * @param {Object[]} statsResponse.metrics Metrics from Sync Server
+ */
+function onStatsResponse(statsResponse) {
+  for(var metricGroup in statsResponse.metrics) {
+    if(!document.getElementById(metricGroup)) {
+      createStatSection(metricGroup, document.getElementById('stats-container'));
+    }
+
+    for(var stat in statsResponse.metrics[metricGroup]) {
+      var statValue = statsResponse.metrics[metricGroup][stat].current;
+      if(typeof statsResponse.metrics[metricGroup][stat] === 'string') {
+        statValue = statsResponse.metrics[metricGroup][stat];
+      }
+
+      var cardConfig = {
+        elementId: stat,
+        idPrefix: metricGroup,
+        title: stat,
+        value: statValue
+      };
+
+      if(document.getElementById(metricGroup + stat)) {
+        updateStatCard(cardConfig);
+      } else {
+        createStatCard(cardConfig, document.getElementById(metricGroup));
+      }
+    }
+  }
+}
+
+$(document).ready(function() {
+  // Do an initial get so the page has values fast, then poll.
+  retrieveSyncStats(onStatsResponse);
+  setInterval(retrieveSyncStats.bind(null, onStatsResponse), 5000);
+});


### PR DESCRIPTION
Add an initial dashboard for sync server.

This is the start of the sync server dashboard. It's a basic
representation of the /sys/info/stats response JSON using cards.

Some things that will probably want to be added in the future:

* Charts/graphs instead of cards for some metrics, timings etc
* Navigation bar when adding the config screen
* Better support for errors/missing data

Ensure you have a server that has been synced against at least once so that metrics is enabled. Go to /dashboard.html

For macs CPU will never work.

<img width="1409" alt="screen shot 2017-08-22 at 10 03 58" src="https://user-images.githubusercontent.com/8698527/29557626-9c1edba0-8721-11e7-9643-9b00ff959907.png">

@david-martin Would you mind taking a look? Wasn't sure how far to go with this.