### PR TITLE
FH-4233 Allow for basic API key authentication

### DIFF
--- a/src/api-key-auth.js
+++ b/src/api-key-auth.js
@@ -1,0 +1,20 @@
+/**
+ * Middleware to protect a service based on whether is has provided a valid API
+ * key.
+ */
+function _protect(apiKeys, req, res, next) {
+  const appID = req.header('app_id');
+  const appKey = req.header('app_key');
+  // Only continue if the keys match up
+  if (appID && appKey && apiKeys[appID] === appKey) {
+    return next();
+  }
+  res.status(403);
+  return res.end('Access denied');
+}
+
+function protect(apiKeys) {
+  return _protect.bind(null, apiKeys);
+}
+
+module.exports = { protect };


### PR DESCRIPTION
Allow the API keysthat are stored in a secret to be mounted in the sync service. The sync service will pick up the mounted files and use them to perform a basic check on the App ID and API key.